### PR TITLE
Additional style tweaks to thread-safe implementation + move LFS_TRACE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -208,6 +208,22 @@ jobs:
     script:
       - make test TFLAGS+="-k --valgrind"
 
+  # test compilation in thread-safe mode
+  - stage: test
+    env:
+      - NAME=littlefs-threadsafe
+      - CC="arm-linux-gnueabi-gcc --static -mthumb"
+      - CFLAGS="-Werror -DLFS_THREADSAFE"
+    if: branch !~ -prefix$
+    install:
+      - *install-common
+      - sudo apt-get install
+            gcc-arm-linux-gnueabi
+            libc6-dev-armel-cross
+      - arm-linux-gnueabi-gcc --version
+    # report-size will compile littlefs and report the size
+    script: [*report-size]
+
   # self-host with littlefs-fuse for fuzz test
   - stage: test
     env:

--- a/lfs.h
+++ b/lfs.h
@@ -16,6 +16,7 @@ extern "C"
 {
 #endif
 
+
 /// Version info ///
 
 // Software library version
@@ -656,6 +657,7 @@ int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 // Returns a negative error code on failure.
 int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg);
 #endif
+
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lfs.h
+++ b/lfs.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <lfs_util.h>
+#include "lfs_util.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -174,7 +174,7 @@ struct lfs_config {
     // are propogated to the user.
     int (*sync)(const struct lfs_config *c);
 
-#if LFS_THREADSAFE
+#ifdef LFS_THREADSAFE
     // Lock the underlying block device. Negative error codes
     // are propogated to the user.
     int (*lock)(const struct lfs_config *c);

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -43,6 +43,7 @@ extern "C"
 {
 #endif
 
+
 // Macros, may be replaced by system specific wrappers. Arguments to these
 // macros must not have side-effects as the macros can be removed for a smaller
 // code footprint

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -43,11 +43,6 @@ extern "C"
 {
 #endif
 
-// Enables thread-safe wrappers using the lock/unlock callbacks in lfs_config
-#ifndef LFS_THREADSAFE
-#define LFS_THREADSAFE 0
-#endif
-
 // Macros, may be replaced by system specific wrappers. Arguments to these
 // macros must not have side-effects as the macros can be removed for a smaller
 // code footprint


### PR DESCRIPTION
From https://github.com/littlefs-project/littlefs/pull/470, I went ahead and added some style tweaks + moved over LFS_TRACE into the new wrappers (nicely cleans some of the intertwining LFS_TRACE calls).

- Stayed on non-system include for lfs_util.h for now
- Named internal functions "lfs_functionraw"
- Merged lfs_fs_traverseraw
- Added LFS_LOCK/UNLOCK macros
- Changed LFS_THREADSAFE from 1/0 to defined/undefined to match LFS_READONLY
- Moved LFS_TRACE calls to API wrapper function


